### PR TITLE
chore: bump Cargo.toml to 0.1.4 for v0.1.4 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4591,7 +4591,7 @@ dependencies = [
 
 [[package]]
 name = "vai"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vai"
-version = "0.1.2"
+version = "0.1.4"
 edition = "2021"
 description = "A version control system built for AI agents"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump Cargo.toml from 0.1.2 → 0.1.4
- Regenerate Cargo.lock

## Context

The v0.1.3 release tag was pushed but its build failed the version-check CI guard added by #297 because Cargo.toml was still 0.1.2. Skipping ahead to 0.1.4 since v0.1.3 is already taken by that failed build and republishing over an existing tag is risky.

v0.1.4 will include:
- #298 — vai login ephemeral port range fix
- #299 — device-code credentials fields + verification_url
- #300 — delta upload threshold + test hardening
- #301 — vai init reads ~/.vai/credentials.toml
- #302 — vai init persists server-assigned repo_id

## Test plan

- [ ] CI `version-check` job passes (this PR is specifically to make it pass on next tag push)
- [ ] `cargo test` / `cargo test --features full` / clippy / audit all clean
- [ ] After merge + `git tag v0.1.4 && git push --tags`, the release workflow publishes binaries that report `vai 0.1.4` via `vai --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)